### PR TITLE
Amends code highlight style, due to Jekyll update

### DIFF
--- a/css/screen.scss
+++ b/css/screen.scss
@@ -142,6 +142,7 @@ body {
 		position: relative;
 		background: darken($light-background, 3%);
 		padding: 20px 15px 1px;
+		margin: 0;
 	}
 	code[data-lang]:before {
 		font-family: "Helvetica Neue", Helvetica, arial, sans-serif;


### PR DESCRIPTION
Unsure on which update but the highlighter we are using for code blocks changed the element that wraps them. `.highlight` is now a `<figure>` instead of a regular  `<div>`.